### PR TITLE
Enable AnnualMetrics module to correctly parse an occupancy schedule.

### DIFF
--- a/honeybee_grasshopper_radiance/src/HB Annual Daylight Metrics.py
+++ b/honeybee_grasshopper_radiance/src/HB Annual Daylight Metrics.py
@@ -115,7 +115,7 @@ if all_required_inputs(ghenv.Component):
         max_t = 2000
 
     # process the schedule and sun-up hours
-    schedule = _occ_sch_.values if _occ_sch_ else generate_default_schedule()
+    schedule = _occ_sch_.values() if _occ_sch_ is not None else generate_default_schedule()
     total_occupied_hours = sum(schedule)
     occ_pattern = parse_sun_up_hours(_results, schedule)
 


### PR DESCRIPTION
Unless I'm missing something, the code to parse an occupancy schedule parameter has a couple typos. Without this correction, the default schedule is always generated.

I don't know how your toolchain works in terms of compiling '.py' files into user objects, so my diff is only to the source file.