### PR TITLE
docs: update HB Spatial Daylight Autonomy.py

### DIFF
--- a/honeybee_grasshopper_radiance/src/HB Spatial Daylight Autonomy.py
+++ b/honeybee_grasshopper_radiance/src/HB Spatial Daylight Autonomy.py
@@ -16,11 +16,17 @@ It is defined as the percent of an analysis area (the area where calcuations
 are performed -typically across an entire space) that meets a minimum
 daylight illuminance level for a specified fraction of the operating hours
 per year. The sDA value is expressed as a percentage of area.
+_
+Note: This component will only output a LEED compliant sDA if you've run the
+simulation with blinds and blinds schedules as per the IES-LM-83-12. If you are not
+using the blinds and using this component on a regular DA output, then this is NOT LEED compliant
+_
 
 -
     Args:
         _DA: A data tree of daylight autonomy values output from the "HB Annual Dalyight"
-            recipe or the "HB Annual Daylight Metrics" component.
+            recipe or the "HB Annual Daylight Metrics" component. Note that this simulation has to follow LM83 blinds setup,
+            otherwise we are not showing a sDA, but only the floor area compliant for a DA.
         mesh_: An optional list of Meshes that align with the _DA data tree above, which
             will be used to assign an area to each sensor. If no mesh is connected
             here, it will be assumed that each sensor represents an equal area


### PR DESCRIPTION
Hi @chriswmackey , please don't promise people that they are getting the sDA results when putting this after a regular Annual Daylight component. Everyone is submitting wrong results to LEED after HB (even back from legacy) has been outputting a "sDA" which has been a regular Daylight Autonomy (so NOT a spatial one).